### PR TITLE
docs: add structured data for breadcrumb navigation on projects and w…

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -49,6 +49,23 @@ const websiteLd = JSON.stringify({
     target: `${Astro.site}search?q={search_term_string}`,
     "query-input": "required name=search_term_string",
   },
+  sitenavigationelement: [
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Work",
+      "url": new URL("/work", Astro.site).toString(),
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Projects",
+      "url": new URL("/projects", Astro.site).toString(),
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Search",
+      "url": new URL("/search", Astro.site).toString(),
+    },
+  ],
 });
 ---
 

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -16,9 +16,29 @@ const tags = [
 
 const estimated_initial_size =
   28 + projects.length * 158 + (projects.length - 1) * 12;
+
+const breadcrumbLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": Astro.site,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Projects",
+      "item": new URL(Astro.url.pathname, Astro.site).toString(),
+    }
+  ],
+});
 ---
 
 <PageLayout title={PROJECTS.TITLE} description={PROJECTS.DESCRIPTION}>
+  <script type="application/ld+json" set:html={breadcrumbLd} />
   <TopLayout>
     <div class="animate">
       <h1 class="text-3xl font-semibold text-black dark:text-white mt-2">

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -150,9 +150,29 @@ function calculateDuration(
   if (parts.length === 0) return isPresent ? "Less than a month" : "0 mos";
   return parts.join(" ");
 }
+
+const breadcrumbLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": Astro.site,
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Work",
+      "item": new URL(Astro.url.pathname, Astro.site).toString(),
+    }
+  ],
+});
 ---
 
 <PageLayout title={WORK.TITLE} description={WORK.DESCRIPTION}>
+  <script type="application/ld+json" set:html={breadcrumbLd} />
   <TopLayout>
     <div class="animate">
       <h1 class="text-3xl font-semibold text-black dark:text-white mt-2">


### PR DESCRIPTION
This pull request enhances the website's structured data for SEO by adding Schema.org markup for site navigation and breadcrumbs. These changes help search engines better understand the site's structure, which can improve how pages appear in search results.

**Structured Data Improvements**

* Added a `sitenavigationelement` array to the JSON-LD in `BaseHead.astro`, providing search engines with explicit information about the main navigation links: Work, Projects, and Search.

**Breadcrumb Schema Additions**

* Added a `BreadcrumbList` JSON-LD schema to `projects/index.astro`, marking up the Home and Projects pages for improved breadcrumb display in search results.
* Added a `BreadcrumbList` JSON-LD schema to `work/index.astro`, marking up the Home and Work pages for improved breadcrumb display in search results.