### PR TITLE
feat: implement article sharing feature with share actions and enhanc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Dark/Light Mode** — Seamless theme switching with user preference persistence.
 - **Search Functionality** — Quickly find projects and work experiences with a built-in search bar.
 - **Content Collections** — Easily manage and update projects and work experiences using Markdown files.
+- **Article Sharing** — Share article pages through a native share sheet, social platforms, and copyable links.
 - **Fast Performance** — Built with Astro for lightning-fast static site generation.
 - **Accessible UI** — Components from Shadcn UI ensure a11y compliance and great UX.
 - **Open Source** — MIT licensed; customize and deploy your own version freely.
@@ -53,7 +54,6 @@ A few features I plan to implement
 
 - 🏆 Honors and Awards page
 - 🔍 Command component feature
-- ⬜ Article Pages - Share on social media
 
 ## 🗂️ Configuration
 

--- a/src/components/ArticleShareActions.tsx
+++ b/src/components/ArticleShareActions.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Copy, Linkedin, Share2 } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { SHARE_DIALOG_CONFIG, getEnabledSharePlatforms } from "@/lib/sharePlatforms";
+import { cn } from "@/lib/utils";
+
+type Props = {
+	title: string;
+	summary: string;
+	url: string;
+	className?: string;
+};
+
+async function copyText(text: string) {
+	if (navigator.clipboard?.writeText) {
+		await navigator.clipboard.writeText(text);
+		return;
+	}
+
+	const textArea = document.createElement("textarea");
+	textArea.value = text;
+	textArea.setAttribute("readonly", "true");
+	textArea.style.position = "absolute";
+	textArea.style.opacity = "0";
+	textArea.style.pointerEvents = "none";
+	document.body.appendChild(textArea);
+	textArea.select();
+	document.execCommand("copy");
+	document.body.removeChild(textArea);
+}
+
+function ShareLink({
+	href,
+	iconHex,
+	iconPath,
+	label,
+	lucideIconName,
+	themeAwareIcon,
+}: {
+	href: string;
+	iconHex?: string;
+	iconPath?: string;
+	label: string;
+	lucideIconName?: "linkedin";
+	themeAwareIcon?: boolean;
+}) {
+	return (
+		<a
+			href={href}
+			target="_blank"
+			rel="noreferrer"
+			aria-label={label}
+			className="group flex h-10 items-center gap-2 rounded-xl border border-black/15 px-3 py-1.5 text-sm text-black transition-colors duration-300 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+		>
+			{lucideIconName === "linkedin" ? (
+				<span
+					className="inline-flex size-4 shrink-0 items-center justify-center text-[#0A66C2]"
+					aria-hidden="true"
+				>
+					<Linkedin className="size-4" strokeWidth={2.1} />
+				</span>
+			) : iconHex && iconPath ? (
+				<span
+					className={cn(
+						"inline-flex size-4 shrink-0 items-center justify-center",
+						themeAwareIcon ? "text-black dark:text-white" : "",
+					)}
+					style={themeAwareIcon ? undefined : { color: `#${iconHex}` }}
+					aria-hidden="true"
+				>
+					<svg
+						viewBox="0 0 24 24"
+						className="size-4 fill-current"
+						focusable="false"
+						aria-hidden="true"
+					>
+						<path d={iconPath} />
+					</svg>
+				</span>
+			) : null}
+			<span>{label}</span>
+		</a>
+	);
+}
+
+export default function ArticleShareActions({
+	title,
+	summary,
+	url,
+	className,
+}: Props) {
+	const [copied, setCopied] = useState(false);
+	const [activeUrl, setActiveUrl] = useState(url);
+	const resetTimerRef = useRef<number | null>(null);
+	const shareLinks = useMemo(() => {
+		return {
+			native: { title, text: `${title}\n\n${summary}`, url: activeUrl },
+			copy: activeUrl,
+		};
+	}, [activeUrl, summary, title]);
+	const enabledPlatforms = useMemo(
+		() =>
+			getEnabledSharePlatforms().map((platform) => ({
+				...platform,
+				href: platform.getHref({ title, summary, url: activeUrl }),
+			})),
+		[activeUrl, summary, title],
+	);
+
+	const canUseNativeShare =
+		typeof navigator !== "undefined" &&
+		"share" in navigator &&
+		SHARE_DIALOG_CONFIG.enableNativeShare;
+
+	useEffect(() => {
+		if (typeof window !== "undefined") {
+			setActiveUrl(window.location.href);
+		}
+
+		return () => {
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current);
+			}
+		};
+	}, []);
+
+	const handleNativeShare = async () => {
+		if (!("share" in navigator)) {
+			return;
+		}
+
+		try {
+			await navigator.share(shareLinks.native);
+		} catch (error) {
+			if (error instanceof DOMException && error.name === "AbortError") {
+				return;
+			}
+
+			toast.error("Share failed. Please try again.");
+		}
+	};
+
+	const handleCopyLink = async () => {
+		try {
+			await copyText(shareLinks.copy);
+			setCopied(true);
+			toast.success("Article link copied");
+			if (resetTimerRef.current !== null) {
+				window.clearTimeout(resetTimerRef.current);
+			}
+			resetTimerRef.current = window.setTimeout(() => {
+				setCopied(false);
+				resetTimerRef.current = null;
+			}, 1800);
+		} catch {
+			toast.error("Copy failed. Please try again.");
+		}
+	};
+
+	return (
+		<Dialog>
+			<DialogTrigger
+				render={
+					<button
+						type="button"
+						className={cn(
+							"group flex gap-2 items-center px-3 py-1.5 truncate rounded text-sm md:text-sm lg:text-base border border-black/25 dark:border-white/25 hover:bg-black/5 hover:dark:bg-white/15 blend",
+							className,
+						)}
+					>
+						<Share2
+							size={16}
+							strokeWidth={2}
+							className="size-4 shrink-0 stroke-current group-hover:stroke-black group-hover:dark:stroke-white"
+							aria-hidden="true"
+						/>
+						<span className="text-current group-hover:text-black group-hover:dark:text-white blend">
+							Share
+						</span>
+					</button>
+				}
+			/>
+			<DialogContent className="max-w-md! border border-black/10 bg-white/95 p-5 dark:border-white/10 dark:bg-black/95">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2 text-base text-black dark:text-white">
+						<Share2 className="size-4" />
+						Share this article
+					</DialogTitle>
+					<DialogDescription>
+						Share <span className="font-medium text-black dark:text-white">{title}</span> on
+						your preferred platform.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="grid gap-2">
+					{canUseNativeShare ? (
+						<button
+							type="button"
+							onClick={handleNativeShare}
+							className="group flex h-10 items-center gap-2 rounded-xl border border-black/15 px-3 py-1.5 text-sm text-black transition-colors duration-300 hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+						>
+							<Share2 className="size-4 shrink-0" />
+							<span>Share using device</span>
+						</button>
+					) : null}
+
+					{enabledPlatforms.map((platform) => (
+						<ShareLink
+							key={platform.id}
+							href={platform.href}
+							iconHex={platform.iconHex}
+							iconPath={platform.iconPath}
+							label={platform.label}
+							lucideIconName={platform.lucideIconName}
+							themeAwareIcon={platform.themeAwareIcon}
+						/>
+					))}
+
+					<div className="mt-1 flex items-center gap-2 rounded-xl border border-black/15 p-2 dark:border-white/20">
+						<Input
+							readOnly
+							aria-label="Article link"
+							value={shareLinks.copy}
+							onFocus={(event) => event.currentTarget.select()}
+							className="h-10 border-0 bg-black/5 text-sm text-black selection:bg-black/15 focus-visible:ring-0 dark:bg-white/5 dark:text-white dark:selection:bg-white/20"
+						/>
+						<button
+							type="button"
+							onClick={handleCopyLink}
+							className="inline-flex h-10 shrink-0 items-center gap-2 rounded-xl bg-black px-4 text-sm font-medium text-white transition-colors duration-300 hover:bg-black/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 dark:bg-white dark:text-black dark:hover:bg-white/85 dark:focus-visible:ring-white/20"
+							aria-label="Copy article link"
+						>
+							<span className="relative size-4">
+								<Copy
+									className={cn(
+										"absolute inset-0 size-4 transition-all duration-300",
+										copied ? "scale-75 -rotate-12 opacity-0" : "scale-100 opacity-100",
+									)}
+								/>
+								<Check
+									className={cn(
+										"absolute inset-0 size-4 transition-all duration-300",
+										copied ? "scale-100 opacity-100" : "scale-75 rotate-12 opacity-0",
+									)}
+								/>
+							</span>
+							<span>{copied ? "Copied" : "Copy"}</span>
+						</button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/ClientToaster.tsx
+++ b/src/components/ClientToaster.tsx
@@ -1,0 +1,13 @@
+import { Toaster } from "@/components/ui/sonner";
+
+export default function ClientToaster() {
+	return (
+		<Toaster
+			position="top-right"
+			closeButton
+			richColors
+			duration={2200}
+			offset={16}
+		/>
+	);
+}

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,7 +1,7 @@
 ---
 import "@styles/global.css";
 import { Button } from "@/components/ui/button";
-import { Info, X } from "lucide-react";
+import { Cookie, Info, X } from "lucide-react";
 ---
 
 <div
@@ -10,7 +10,7 @@ import { Info, X } from "lucide-react";
     border-black/10 dark:border-white/20
     backdrop-blur-2xl saturate-150
     shadow-lg shadow-black/5 dark:shadow-black/20
-    bottom-24 md:bottom-4"
+    bottom-28 md:bottom-4"
   id="cookie-consent-desktop"
   aria-live="polite"
   hidden
@@ -66,20 +66,34 @@ import { Info, X } from "lucide-react";
 </div>
 
 <div
-  class="md:hidden fixed right-3 bottom-22 z-30 transition-all duration-200 ease-out opacity-0 translate-y-2 scale-95"
-  id="cookie-consent-mobile-trigger"
+  class="fixed right-0 bottom-26 md:bottom-8 z-30 transition-all duration-200 ease-out opacity-0 translate-x-3"
+  id="cookie-consent-trigger"
   hidden
 >
-  <Button
+  <button
     data-consent-toggle="panel"
     type="button"
-    className="inline-flex items-center gap-2 rounded-full px-3 py-2 text-xs font-medium border border-black/10 dark:border-white/20 bg-white/80 dark:bg-black/70 backdrop-blur-xl text-black/90 dark:text-white/90 shadow-md shadow-black/10 dark:shadow-black/30"
-    aria-controls="cookie-consent-mobile-panel"
+    class="inline-flex items-center gap-2 rounded-l-xl rounded-r-none border border-r-0 px-2.5 py-3 text-xs font-medium
+      bg-white/70 dark:bg-black/50
+      border-black/10 dark:border-white/20
+      backdrop-blur-2xl saturate-150
+      text-black/90 dark:text-white/90
+      shadow-md shadow-black/5 dark:shadow-black/20
+      hover:bg-white/80 hover:dark:bg-black/60
+      transition-colors duration-200 cursor-pointer"
+    style="writing-mode: vertical-rl; text-orientation: sideways;"
+    aria-controls="cookie-consent-desktop cookie-consent-mobile-panel"
     aria-expanded="false"
+    aria-label="Open cookie settings"
   >
-    <Info size={14} strokeWidth={2} className="size-3.5 stroke-current" aria-hidden="true" />
-    Cookies
-  </Button>
+    <Cookie
+      size={14}
+      strokeWidth={2}
+      className="size-3.5 stroke-current"
+      aria-hidden="true"
+    />
+    <span>Cookie Settings</span>
+  </button>
 </div>
 
 <div
@@ -88,7 +102,7 @@ import { Info, X } from "lucide-react";
     border-black/10 dark:border-white/20
     backdrop-blur-2xl saturate-150
     shadow-lg shadow-black/5 dark:shadow-black/20
-    bottom-24 md:hidden z-30 transition-all duration-250 ease-out opacity-0 translate-y-4 scale-95 pointer-events-none"
+    bottom-26 md:hidden z-30 transition-all duration-250 ease-out opacity-0 translate-y-4 scale-95 pointer-events-none"
   id="cookie-consent-mobile-panel"
   aria-live="polite"
   aria-modal="false"
@@ -152,13 +166,11 @@ import { Info, X } from "lucide-react";
       const dismissedKey = "site:analytics:dismissed";
       const desktopEl = document.getElementById("cookie-consent-desktop");
       const mobilePanel = document.getElementById("cookie-consent-mobile-panel");
-      const mobileTrigger = document.getElementById(
-        "cookie-consent-mobile-trigger",
-      );
-      const mobileToggleBtn = mobileTrigger
-        ? mobileTrigger.querySelector("[data-consent-toggle='panel']")
+      const triggerEl = document.getElementById("cookie-consent-trigger");
+      const toggleBtn = triggerEl
+        ? triggerEl.querySelector("[data-consent-toggle='panel']")
         : null;
-      let mobileTriggerCloseTimer = null;
+      let triggerCloseTimer = null;
       let mobilePanelCloseTimer = null;
       const accepted = localStorage.getItem(storageKey);
       const dismissed = localStorage.getItem(dismissedKey);
@@ -169,15 +181,15 @@ import { Info, X } from "lucide-react";
           window.matchMedia("(max-width: 767px)").matches
         );
       }
-      function setMobileExpanded(expanded) {
-        if (mobileToggleBtn) {
-          mobileToggleBtn.setAttribute("aria-expanded", expanded ? "true" : "false");
+      function setTriggerExpanded(expanded) {
+        if (toggleBtn) {
+          toggleBtn.setAttribute("aria-expanded", expanded ? "true" : "false");
         }
       }
       function clearTriggerCloseTimer() {
-        if (mobileTriggerCloseTimer) {
-          clearTimeout(mobileTriggerCloseTimer);
-          mobileTriggerCloseTimer = null;
+        if (triggerCloseTimer) {
+          clearTimeout(triggerCloseTimer);
+          triggerCloseTimer = null;
         }
       }
       function clearPanelCloseTimer() {
@@ -186,26 +198,28 @@ import { Info, X } from "lucide-react";
           mobilePanelCloseTimer = null;
         }
       }
-      function showMobileTrigger() {
-        if (!mobileTrigger) return;
+      function showTrigger() {
+        if (!triggerEl) return;
         clearTriggerCloseTimer();
-        mobileTrigger.hidden = false;
+        triggerEl.hidden = false;
         requestAnimationFrame(function () {
-          mobileTrigger.classList.remove("opacity-0", "translate-y-2", "scale-95");
-          mobileTrigger.classList.add("opacity-100", "translate-y-0", "scale-100");
+          triggerEl.classList.remove("opacity-0", "translate-x-3");
+          triggerEl.classList.add("opacity-100", "translate-x-0");
         });
       }
-      function hideMobileTrigger(animated) {
-        if (!mobileTrigger) return;
+      function hideTrigger(animated) {
+        if (!triggerEl) return;
         clearTriggerCloseTimer();
         if (!animated) {
-          mobileTrigger.hidden = true;
+          triggerEl.hidden = true;
+          triggerEl.classList.remove("opacity-100", "translate-x-0");
+          triggerEl.classList.add("opacity-0", "translate-x-3");
           return;
         }
-        mobileTrigger.classList.remove("opacity-100", "translate-y-0", "scale-100");
-        mobileTrigger.classList.add("opacity-0", "translate-y-2", "scale-95");
-        mobileTriggerCloseTimer = window.setTimeout(function () {
-          if (mobileTrigger) mobileTrigger.hidden = true;
+        triggerEl.classList.remove("opacity-100", "translate-x-0");
+        triggerEl.classList.add("opacity-0", "translate-x-3");
+        triggerCloseTimer = window.setTimeout(function () {
+          if (triggerEl) triggerEl.hidden = true;
         }, 220);
       }
       function openMobilePanel() {
@@ -264,29 +278,49 @@ import { Info, X } from "lucide-react";
       }
       function show() {
         if (isMobile()) {
-          showMobileTrigger();
+          hideTrigger(false);
           closeMobilePanel(false);
-          setMobileExpanded(false);
+          openMobilePanel();
+          setTriggerExpanded(true);
           if (desktopEl) desktopEl.hidden = true;
           return;
         }
         if (desktopEl) desktopEl.hidden = false;
-        hideMobileTrigger(false);
+        hideTrigger(false);
         closeMobilePanel(false);
-        setMobileExpanded(false);
+        setTriggerExpanded(true);
       }
       function hide() {
         if (desktopEl) desktopEl.hidden = true;
-        hideMobileTrigger(true);
+        hideTrigger(true);
         closeMobilePanel(true);
-        setMobileExpanded(false);
+        setTriggerExpanded(false);
       }
-      function toggleMobilePanel() {
-        if (!mobilePanel || !mobileTrigger || mobileTrigger.hidden) return;
-        const willOpen = mobilePanel.hidden;
-        if (willOpen) openMobilePanel();
-        else closeMobilePanel(true);
-        setMobileExpanded(willOpen);
+      function hidePanels() {
+        if (desktopEl) desktopEl.hidden = true;
+        closeMobilePanel(false);
+        setTriggerExpanded(false);
+      }
+      function togglePanel() {
+        if (isMobile()) {
+          const willOpen = mobilePanel ? mobilePanel.hidden : false;
+          if (willOpen) {
+            hideTrigger(false);
+            openMobilePanel();
+          } else {
+            closeMobilePanel(true);
+            showTrigger();
+          }
+          setTriggerExpanded(willOpen);
+          return;
+        }
+
+        if (!desktopEl) return;
+        const willOpen = desktopEl.hidden;
+        desktopEl.hidden = !willOpen ? true : false;
+        if (willOpen) hideTrigger(false);
+        else showTrigger();
+        setTriggerExpanded(willOpen);
       }
 
       function loadAnalytics() {
@@ -356,15 +390,8 @@ import { Info, X } from "lucide-react";
       } else if (accepted === "false") {
         hide();
       } else if (dismissed === "true") {
-        if (isMobile()) {
-          showMobileTrigger();
-          closeMobilePanel(false);
-          setMobileExpanded(false);
-          if (desktopEl) desktopEl.hidden = true;
-        } else {
-          localStorage.removeItem(dismissedKey);
-          show();
-        }
+        showTrigger();
+        hidePanels();
       } else {
         show();
       }
@@ -377,20 +404,13 @@ import { Info, X } from "lucide-react";
         const closeEl = t.closest("[data-consent-close='panel']");
 
         if (toggleEl) {
-          toggleMobilePanel();
+          togglePanel();
           return;
         }
         if (closeEl) {
-          if (isMobile()) {
-            localStorage.setItem(dismissedKey, "true");
-            showMobileTrigger();
-            closeMobilePanel(true);
-            setMobileExpanded(false);
-            if (desktopEl) desktopEl.hidden = true;
-          } else {
-            localStorage.removeItem(dismissedKey);
-            if (desktopEl) desktopEl.hidden = true;
-          }
+          localStorage.setItem(dismissedKey, "true");
+          hidePanels();
+          showTrigger();
           return;
         }
 
@@ -416,6 +436,11 @@ import { Info, X } from "lucide-react";
         const current = localStorage.getItem(storageKey);
         if (current === "true" || current === "false") {
           hide();
+          return;
+        }
+        if (localStorage.getItem(dismissedKey) === "true") {
+          showTrigger();
+          hidePanels();
           return;
         }
         show();

--- a/src/components/MarkdownEnhancer.tsx
+++ b/src/components/MarkdownEnhancer.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Check, Copy } from "lucide-react";
+import { toast } from "sonner";
+
+import { cn } from "@/lib/utils";
+
+type CopyCodeButtonProps = {
+	getText: () => string;
+};
+
+async function copyText(text: string) {
+	if (navigator.clipboard?.writeText) {
+		await navigator.clipboard.writeText(text);
+		return;
+	}
+
+	const textArea = document.createElement("textarea");
+	textArea.value = text;
+	textArea.setAttribute("readonly", "true");
+	textArea.style.position = "absolute";
+	textArea.style.opacity = "0";
+	textArea.style.pointerEvents = "none";
+	document.body.appendChild(textArea);
+	textArea.select();
+	document.execCommand("copy");
+	document.body.removeChild(textArea);
+}
+
+function CopyCodeButton({ getText }: CopyCodeButtonProps) {
+	const [copied, setCopied] = useState(false);
+	const timeoutRef = useRef<number | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (timeoutRef.current !== null) {
+				window.clearTimeout(timeoutRef.current);
+			}
+		};
+	}, []);
+
+	const handleCopy = async () => {
+		try {
+			await copyText(getText());
+			setCopied(true);
+			toast.success("Code copied to clipboard");
+
+			if (timeoutRef.current !== null) {
+				window.clearTimeout(timeoutRef.current);
+			}
+
+			timeoutRef.current = window.setTimeout(() => {
+				setCopied(false);
+				timeoutRef.current = null;
+			}, 1800);
+		} catch {
+			toast.error("Copy failed. Please try again.");
+		}
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className={cn(
+				"code-copy-button inline-flex size-8 items-center justify-center rounded-lg border border-black/10 bg-white/85 text-black transition-all duration-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/20 dark:border-white/15 dark:bg-black/80 dark:text-white dark:hover:bg-black",
+				copied ? "is-copied" : "",
+			)}
+			aria-label={copied ? "Code copied" : "Copy code"}
+		>
+			<span className="relative size-4">
+				<Copy
+					className={cn(
+						"absolute inset-0 size-4 transition-all duration-300",
+						copied ? "scale-75 -rotate-12 opacity-0" : "scale-100 opacity-100",
+					)}
+				/>
+				<Check
+					className={cn(
+						"absolute inset-0 size-4 transition-all duration-300",
+						copied ? "scale-100 opacity-100" : "scale-75 rotate-12 opacity-0",
+					)}
+				/>
+			</span>
+		</button>
+	);
+}
+
+type MountedControl = {
+	host: HTMLDivElement;
+	owner: HTMLElement;
+	root: Root;
+};
+
+export default function MarkdownEnhancer() {
+	useEffect(() => {
+		const mountedControls: MountedControl[] = [];
+		const codeBlocks = document.querySelectorAll<HTMLElement>(
+			"[data-enhance-codeblocks] pre",
+		);
+
+		for (const block of codeBlocks) {
+			if (block.dataset.copyEnhanced === "true") {
+				continue;
+			}
+
+			const code = block.querySelector("code");
+			const getText = () => {
+				const rawText = code?.textContent ?? block.textContent ?? "";
+				return rawText.replace(/\n$/, "");
+			};
+
+			block.dataset.copyEnhanced = "true";
+			block.classList.add("has-code-copy");
+
+			const host = document.createElement("div");
+			host.className = "code-copy-host";
+			block.appendChild(host);
+
+			const root = createRoot(host);
+			root.render(<CopyCodeButton getText={getText} />);
+
+			mountedControls.push({ host, owner: block, root });
+		}
+
+		return () => {
+			for (const { host, owner, root } of mountedControls) {
+				root.unmount();
+				host.remove();
+				delete owner.dataset.copyEnhanced;
+				owner.classList.remove("has-code-copy");
+			}
+		};
+	}, []);
+
+	return null;
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
 
 import { cn } from "@/lib/utils"

--- a/src/content/projects/2023/portfolio.md
+++ b/src/content/projects/2023/portfolio.md
@@ -36,6 +36,7 @@ coverAlt: 'Personal Online Portfolio Website'
 - **Dark/Light Mode** — Seamless theme switching with user preference persistence.
 - **Search Functionality** — Quickly find projects and work experiences with a built-in search bar.
 - **Content Collections** — Easily manage and update projects and work experiences using Markdown files.
+- **Article Sharing** — Share article pages through a native share sheet, social platforms, and copyable links.
 - **Fast Performance** — Built with Astro for lightning-fast static site generation.
 - **Accessible UI** — Components from Shadcn UI ensure a11y compliance and great UX.
 - **Open Source** — MIT licensed; customize and deploy your own version freely.
@@ -81,7 +82,6 @@ A few features I plan to implement
 
 - 🏆 Honors and Awards page
 - 🔍 Command component feature
-- ⬜ Article Pages - Share on social media
 
 ---
 
@@ -125,4 +125,3 @@ Check out `Contributing.md` to learn how to get started and follow the recommend
 This project is released under the MIT License, giving you the freedom to use, modify, and distribute the code with minimal restrictions.
 
 For the full legal text, see the `MIT` file.
-

--- a/src/layouts/ArticleBottomLayout.astro
+++ b/src/layouts/ArticleBottomLayout.astro
@@ -33,6 +33,7 @@ const next = items[(index + 1) % items.length];
 <div>
   <article
     class="article-content"
+    data-enhance-codeblocks
     data-has-resolved-preview={shouldHideMarkdownCoverImage ? "true" : "false"}
   >
     {

--- a/src/layouts/ArticleTopLayout.astro
+++ b/src/layouts/ArticleTopLayout.astro
@@ -1,16 +1,19 @@
 ---
 import type { CollectionEntry } from "astro:content";
 import { formatDate, readingTime } from "@lib/utils";
+import ArticleShareActions from "@components/ArticleShareActions";
 
 import { Calendar, BookOpen, Globe, LinkIcon, ChevronLeft } from "lucide-react";
 
 type Props = {
   entry: CollectionEntry<"projects">;
+  shareUrl: string;
 };
 
 const { entry } = Astro.props;
-const { collection, data, body } = entry;
+const { collection, data, body = "" } = entry;
 const { title, summary, date } = data;
+const { shareUrl } = Astro.props;
 
 const demoUrl = collection === "projects" ? data.demoUrl : null;
 const repoUrl = collection === "projects" ? data.repoUrl : null;
@@ -65,7 +68,7 @@ const repoUrl = collection === "projects" ? data.repoUrl : null;
   </div>
 
   {
-    (demoUrl || repoUrl) && (
+    (demoUrl || repoUrl || shareUrl) && (
       <div class="mt-4 flex flex-wrap gap-2">
         {demoUrl && (
           <a
@@ -102,6 +105,13 @@ const repoUrl = collection === "projects" ? data.repoUrl : null;
             </span>
           </a>
         )}
+
+        <ArticleShareActions
+          client:load
+          title={title}
+          summary={summary}
+          url={shareUrl}
+        />
       </div>
     )
   }

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -5,6 +5,8 @@ import Drawer from "@components/Drawer.astro";
 import Footer from "@components/Footer.astro";
 import Header from "@components/Header.astro";
 import CookieConsent from "@components/CookieConsent.astro";
+import ClientToaster from "@components/ClientToaster";
+import MarkdownEnhancer from "@components/MarkdownEnhancer";
 const { title, description, image } = Astro.props;
 import { SITE } from "@consts";
 ---
@@ -26,5 +28,7 @@ import { SITE } from "@consts";
     </main>
     <Footer />
     <CookieConsent />
+    <ClientToaster client:load />
+    <MarkdownEnhancer client:load />
   </body>
 </html>

--- a/src/lib/sharePlatforms.ts
+++ b/src/lib/sharePlatforms.ts
@@ -1,0 +1,113 @@
+import * as simpleIcons from "simple-icons";
+import type { SimpleIcon } from "simple-icons";
+
+export type SharePlatformId =
+	| "x"
+	| "linkedin"
+	| "facebook"
+	| "whatsapp"
+	| "telegram"
+	| "reddit"
+	| "email";
+
+export type SharePlatformConfig = {
+	enabled: boolean;
+	id: SharePlatformId;
+};
+
+export type SharePlatformDefinition = {
+	getHref: (params: { title: string; summary: string; url: string }) => string;
+	iconHex?: string;
+	iconPath?: string;
+	id: SharePlatformId;
+	label: string;
+	lucideIconName?: "linkedin";
+	themeAwareIcon?: boolean;
+};
+
+const simpleIconRecords = Object.values(simpleIcons).filter(
+	(value): value is SimpleIcon =>
+		Boolean(value) &&
+		typeof value === "object" &&
+		"title" in value &&
+		"slug" in value &&
+		"hex" in value &&
+		"path" in value,
+);
+
+function normalizeKey(value: string) {
+	return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+const iconLookup = new Map<string, SimpleIcon>();
+
+for (const icon of simpleIconRecords) {
+	iconLookup.set(normalizeKey(icon.slug), icon);
+	iconLookup.set(normalizeKey(icon.title), icon);
+}
+
+function getShareIcon(key: string) {
+	const icon = iconLookup.get(normalizeKey(key));
+
+	if (!icon) {
+		throw new Error(`Missing simple icon for ${key}`);
+	}
+
+	return icon;
+}
+
+const xIcon = getShareIcon("x");
+const facebookIcon = getShareIcon("facebook");
+const redditIcon = getShareIcon("reddit");
+
+export const SHARE_DIALOG_CONFIG = {
+	enableNativeShare: true,
+	platforms: [
+		{ id: "x", enabled: true },
+		{ id: "linkedin", enabled: true },
+		{ id: "facebook", enabled: true },
+		{ id: "reddit", enabled: true },
+	] satisfies SharePlatformConfig[],
+} as const;
+
+const sharePlatformDefinitions = {
+	x: {
+		id: "x",
+		label: "Share on X",
+		iconHex: xIcon.hex,
+		iconPath: xIcon.path,
+		themeAwareIcon: true,
+		getHref: ({ title, url }) =>
+			`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+	},
+	linkedin: {
+		id: "linkedin",
+		label: "Share on LinkedIn",
+		lucideIconName: "linkedin",
+		getHref: ({ url }) =>
+			`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+	},
+	facebook: {
+		id: "facebook",
+		label: "Share on Facebook",
+		iconHex: facebookIcon.hex,
+		iconPath: facebookIcon.path,
+		getHref: ({ url }) =>
+			`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`,
+	},
+	reddit: {
+		id: "reddit",
+		label: "Share on Reddit",
+		iconHex: redditIcon.hex,
+		iconPath: redditIcon.path,
+		getHref: ({ title, url }) =>
+			`https://www.reddit.com/submit?url=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`,
+	},
+} satisfies Partial<Record<SharePlatformId, SharePlatformDefinition>>;
+
+export function getEnabledSharePlatforms() {
+	return SHARE_DIALOG_CONFIG.platforms
+		.filter((platform) => platform.enabled)
+		.map((platform) => sharePlatformDefinitions[platform.id])
+		.filter(Boolean) as SharePlatformDefinition[];
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -173,7 +173,7 @@ const mobileStackRows = chunkStack(stack, 3);
 							download="Resume.pdf"
 							class="group flex items-center gap-2 py-2 px-4 rounded-lg truncate text-sm md:text-sm lg:text-base bg-black dark:bg-white text-white dark:text-black hover:opacity-75 blend"
 						>
-							<FileText size={16} strokeWidth={2} className="size-4 stroke-current mr-2" aria-hidden="true" />
+							<FileText size={16} strokeWidth={2} className="size-4 stroke-current" aria-hidden="true" />
 							<span>Check my resume</span>
 						</a>
 						<a
@@ -181,7 +181,7 @@ const mobileStackRows = chunkStack(stack, 3);
 							class="group flex items-center gap-2 py-2 px-4 truncate-lg rounded-lg text-sm md:text-sm lg:text-base border border-black/25 dark:border-white/25 hover:bg-black/5 hover:dark:bg-white/15 blend"
 						>
 							<span>View my projects</span>
-							<ChevronRight size={16} strokeWidth={2} className="size-4 stroke-current ml-2" aria-hidden="true" />
+							<ChevronRight size={16} strokeWidth={2} className="size-4 stroke-current" aria-hidden="true" />
 						</a>
 					</div>
 				</div>

--- a/src/pages/legal/[...slug].astro
+++ b/src/pages/legal/[...slug].astro
@@ -5,6 +5,7 @@ import PageLayout from "@layouts/PageLayout.astro";
 import TopLayout from "@layouts/TopLayout.astro";
 import { formatDate } from "@lib/utils";
 import { SITE } from "@consts";
+import ArticleShareActions from "@components/ArticleShareActions";
 
 // Enable static prerendering
 export const prerender = true;
@@ -23,6 +24,7 @@ type Props = CollectionEntry<"legal">;
 const doc = Astro.props;
 const { title, date } = doc.data;
 const { Content } = await render(doc);
+const shareUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <PageLayout title={title} description={`${title} for ${SITE.TITLE}`}>
@@ -34,10 +36,18 @@ const { Content } = await render(doc);
       <p class="font-normal opacity-75">
         Last updated: {formatDate(date)}
       </p>
+      <div class="mt-4">
+        <ArticleShareActions
+          client:load
+          title={title}
+          summary={`${title} for ${SITE.TITLE}`}
+          url={shareUrl}
+        />
+      </div>
     </div>
   </TopLayout>
   <BottomLayout>
-    <article class="animate">
+    <article class="animate article-content" data-enhance-codeblocks>
       <Content />
     </article>
   </BottomLayout>

--- a/src/pages/projects/[...slug].astro
+++ b/src/pages/projects/[...slug].astro
@@ -35,12 +35,13 @@ const { title, summary } = project.data;
 const resolvedPreview =
   project.data.previewImage ?? (await resolveProjectPreview(project));
 const ogImageUrl = resolvedPreview ?? "/og-card.jpg";
+const shareUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <PageLayout title={title} description={summary} image={ogImageUrl}>
   <TopLayout>
     <div class="animate">
-      <ArticleTopLayout entry={project} />
+      <ArticleTopLayout entry={project} shareUrl={shareUrl} />
     </div>
   </TopLayout>
   <BottomLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -399,10 +399,12 @@
 	}
 
 	article pre {
+		position: relative;
 		background: rgba(0, 0, 0, 0.04);
 		padding: 1rem;
-		border-radius: 0.5rem;
+		border-radius: 1rem;
 		overflow: auto;
+		border: 1px solid rgba(0, 0, 0, 0.08);
 	}
 
 	article code {
@@ -603,6 +605,68 @@
 		color: var(--muted-foreground);
 		font-size: 0.95rem;
 		opacity: 0.95;
+	}
+
+	.article-content pre,
+	article[data-enhance-codeblocks] pre {
+		background: color-mix(in srgb, var(--foreground) 6%, transparent);
+		padding: 1rem;
+		border-radius: 1rem;
+		border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+		overflow: auto;
+	}
+
+	.article-content pre code,
+	article[data-enhance-codeblocks] pre code {
+		background: transparent;
+		padding: 0;
+		border-radius: 0;
+		font-size: 0.95rem;
+		line-height: 1.75;
+		display: inline;
+		min-width: 0;
+		white-space: pre;
+	}
+
+	.code-copy-host {
+		position: absolute;
+		top: 0.75rem;
+		right: 0.75rem;
+		z-index: 1;
+	}
+
+	.code-copy-button {
+		opacity: 0;
+		transform: translateY(-4px) scale(0.96);
+		pointer-events: none;
+	}
+
+	.article-content pre:hover .code-copy-button,
+	.article-content pre:focus-within .code-copy-button,
+	article[data-enhance-codeblocks] pre:hover .code-copy-button,
+	article[data-enhance-codeblocks] pre:focus-within .code-copy-button,
+	.code-copy-button.is-copied {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+		pointer-events: auto;
+	}
+
+	.code-copy-button.is-copied {
+		animation: code-copy-pop 0.35s ease;
+	}
+
+	@keyframes code-copy-pop {
+		0% {
+			transform: scale(0.94);
+		}
+
+		60% {
+			transform: scale(1.04);
+		}
+
+		100% {
+			transform: scale(1);
+		}
 	}
 
 


### PR DESCRIPTION
## Description
Adds article sharing and copy-to-clipboard enhancements across article, legal, and project pages, plus supporting UI refinements like enhanced markdown code blocks, updated cookie consent behavior, and toaster wiring for feedback.

## Related Issue
N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 Style/UI update
- [x] ♻️ Refactor (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change


## Changes Made
- Added an article share dialog with native share support, social platform links, and copy-link actions.
- Added markdown/code block enhancement so article code samples get copy buttons and better visual treatment.
- Updated article, legal, and project layouts to surface share actions and enable code-block enhancements.
- Refined cookie consent behavior and a few UI details for consistency across mobile and desktop.
- Added client-side toaster support for share/copy feedback.

## Screenshots/Recordings
| Before | After |
|--------|-------|
|        |       |

## Testing
<!-- Describe the tests you ran and how to reproduce them -->

- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist
<!-- Ensure all items are completed before requesting review -->

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [ x My changes generate no new warnings or errors
- [x] I have checked for accessibility compliance
- [x] I have verified responsive design (if applicable)

## Additional Notes
Branch created locally as `feature/article-sharing-and-code-enhancements`. Changes have not been pushed.