### PR TITLE
Feat/agent readiness discovery

### DIFF
--- a/public/js/webmcp.js
+++ b/public/js/webmcp.js
@@ -1,0 +1,209 @@
+// WebMCP tool registration for browser-based agents.
+(function () {
+  function normalizePath(inputPath) {
+    if (typeof inputPath !== "string") return null;
+
+    var trimmed = inputPath.trim();
+    if (!trimmed) return null;
+
+    try {
+      var asUrl = new URL(trimmed, window.location.origin);
+      if (asUrl.origin !== window.location.origin) return null;
+      return asUrl.pathname + asUrl.search + asUrl.hash;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function countMatches(haystack, needle) {
+    if (!needle) return 0;
+
+    var count = 0;
+    var index = 0;
+    var source = haystack.toLowerCase();
+    var query = needle.toLowerCase();
+
+    while (index < source.length) {
+      var foundAt = source.indexOf(query, index);
+      if (foundAt === -1) break;
+      count += 1;
+      index = foundAt + query.length;
+    }
+
+    return count;
+  }
+
+  function getTextContent() {
+    var root = document.querySelector("main") || document.body;
+    return root ? root.textContent || "" : "";
+  }
+
+  function openSearchDialog() {
+    try {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          metaKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "k",
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    } catch (error) {
+      // no-op
+    }
+  }
+
+  function getTools() {
+    return [
+      {
+        name: "site.navigate",
+        description:
+          "Navigate to an internal page on this site by path, such as /projects or /work.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            path: {
+              type: "string",
+              description: "A site-relative path to navigate to.",
+            },
+          },
+          required: ["path"],
+          additionalProperties: false,
+        },
+        execute: async function (input) {
+          var nextPath = normalizePath(input && input.path);
+          if (!nextPath) {
+            return {
+              ok: false,
+              error: "Invalid path. Use a path on the current origin, e.g. /projects.",
+            };
+          }
+
+          window.location.assign(nextPath);
+
+          return {
+            ok: true,
+            navigatedTo: nextPath,
+          };
+        },
+        annotations: {
+          readOnlyHint: false,
+        },
+      },
+      {
+        name: "site.find_text",
+        description:
+          "Search visible page content and return the number of matches for a query string.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Text to search for in the current page content.",
+            },
+          },
+          required: ["query"],
+          additionalProperties: false,
+        },
+        execute: async function (input) {
+          var query = (input && input.query ? String(input.query) : "").trim();
+          if (!query) {
+            return {
+              ok: false,
+              error: "Query is required.",
+            };
+          }
+
+          var text = getTextContent();
+          return {
+            ok: true,
+            query: query,
+            matches: countMatches(text, query),
+          };
+        },
+        annotations: {
+          readOnlyHint: true,
+        },
+      },
+      {
+        name: "site.open_search",
+        description:
+          "Open the site's global search dialog.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: async function () {
+          openSearchDialog();
+          return {
+            ok: true,
+            message: "Search dialog open command dispatched.",
+          };
+        },
+        annotations: {
+          readOnlyHint: false,
+        },
+      },
+    ];
+  }
+
+  function registerWebMcpTools() {
+    if (typeof window === "undefined" || typeof navigator === "undefined") return;
+
+    var modelContext = navigator.modelContext;
+    if (!modelContext) return;
+
+    var tools = getTools();
+
+    if (typeof modelContext.registerTool === "function") {
+      var controller = new AbortController();
+
+      tools.forEach(function (tool) {
+        try {
+          modelContext.registerTool(tool, { signal: controller.signal });
+        } catch (error) {
+          // Ignore duplicate or unsupported registration errors to keep page stable.
+        }
+      });
+
+      window.addEventListener(
+        "pagehide",
+        function () {
+          controller.abort();
+        },
+        { once: true },
+      );
+
+      return;
+    }
+
+    if (typeof modelContext.provideContext === "function") {
+      try {
+        modelContext.provideContext({ tools: tools });
+      } catch (error) {
+        // no-op
+      }
+    }
+  }
+
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", registerWebMcpTools, {
+        once: true,
+      });
+    } else {
+      registerWebMcpTools();
+    }
+
+    document.addEventListener("astro:after-swap", registerWebMcpTools);
+  }
+})();

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -224,6 +224,7 @@ const structuredDataLd = JSON.stringify({
 <script type="module" src="/js/theme.js"></script>
 <script type="module" src="/js/scroll.js"></script>
 <script type="module" src="/js/animate.js"></script>
+<script type="module" src="/js/webmcp.js"></script>
 <script>
   import { injectSpeedInsights } from "@vercel/speed-insights";
 

--- a/src/lib/agentDiscovery.ts
+++ b/src/lib/agentDiscovery.ts
@@ -1,0 +1,37 @@
+import type { APIContext } from "astro";
+
+const FALLBACK_ORIGIN = "https://kurtcalacday.vercel.app";
+
+export function getSiteBaseUrl(site?: APIContext["site"]): URL {
+	if (site instanceof URL) {
+		return site;
+	}
+
+	return new URL(FALLBACK_ORIGIN);
+}
+
+export function toAbsoluteUrl(pathname: string, site?: APIContext["site"]): string {
+	return new URL(pathname, getSiteBaseUrl(site)).toString();
+}
+
+export function jsonResponse(
+	payload: unknown,
+	options?: {
+		status?: number;
+		headers?: HeadersInit;
+		contentType?: string;
+	},
+): Response {
+	const status = options?.status ?? 200;
+	const contentType = options?.contentType ?? "application/json; charset=utf-8";
+	const headers = new Headers(options?.headers);
+
+	if (!headers.has("Content-Type")) {
+		headers.set("Content-Type", contentType);
+	}
+
+	return new Response(JSON.stringify(payload, null, 2), {
+		status,
+		headers,
+	});
+}

--- a/src/lib/agentSkills.ts
+++ b/src/lib/agentSkills.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+
+export type AgentSkillArtifact = {
+	name: string;
+	description: string;
+	content: string;
+};
+
+const SITE_NAVIGATION_SKILL = `---
+name: site-navigation
+description: Navigate the portfolio site and jump directly to key sections.
+---
+
+# Site Navigation
+
+Use this skill when you need to move around the portfolio quickly.
+
+## Key routes
+
+- Home: /
+- Work: /work
+- Projects: /projects
+- API docs: /docs/api
+
+## Guidance
+
+- Prefer direct route navigation when a destination is known.
+- Use /projects when you need implementation examples.
+- Use /docs/api for machine-readable discovery endpoints.
+`;
+
+const API_DISCOVERY_SKILL = `---
+name: api-discovery
+description: Discover machine-readable API, OAuth, and agent metadata exposed by the site.
+---
+
+# API Discovery
+
+Use this skill when you need to locate machine-readable metadata for agents.
+
+## Discovery endpoints
+
+- API catalog: /.well-known/api-catalog
+- OpenAPI description: /openapi.json
+- OAuth/OIDC discovery:
+	- /.well-known/openid-configuration
+	- /.well-known/oauth-authorization-server
+- OAuth protected resource metadata: /.well-known/oauth-protected-resource
+- MCP server card: /.well-known/mcp/server-card.json
+- Agent skills index: /.well-known/agent-skills/index.json
+
+## Notes
+
+- Prefer /.well-known/api-catalog as the primary machine discovery entry point.
+- Use /docs/api for human-readable guidance.
+`;
+
+const SKILL_ARTIFACTS: Record<string, AgentSkillArtifact> = {
+	"site-navigation": {
+		name: "site-navigation",
+		description: "Navigate the portfolio site and jump directly to key sections.",
+		content: SITE_NAVIGATION_SKILL,
+	},
+	"api-discovery": {
+		name: "api-discovery",
+		description:
+			"Discover machine-readable API, OAuth, and agent metadata exposed by the site.",
+		content: API_DISCOVERY_SKILL,
+	},
+};
+
+export function getAgentSkillArtifact(skillName: string): AgentSkillArtifact | undefined {
+	return SKILL_ARTIFACTS[skillName];
+}
+
+export function getAgentSkillsIndex() {
+	const skills = Object.values(SKILL_ARTIFACTS).map((skill) => ({
+		name: skill.name,
+		type: "skill-md" as const,
+		description: skill.description,
+		url: `/.well-known/agent-skills/${skill.name}/SKILL.md`,
+		digest: `sha256:${createHash("sha256").update(skill.content).digest("hex")}`,
+	}));
+
+	return {
+		$schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+		skills,
+	};
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -124,7 +124,9 @@ export const onRequest = async (
 ) => {
   const response = await next();
   const isMarkdownPreferred =
-    context.request.method === "GET" && acceptsMarkdown(context.request);
+    !context.isPrerendered &&
+    context.request.method === "GET" &&
+    acceptsMarkdown(context.request);
 
   let requestUrl: URL | undefined;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,151 @@
 import type { APIContext, MiddlewareNext } from "astro";
 
+const AGENT_DISCOVERY_LINKS = [
+  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
+  '</openapi.json>; rel="service-desc"; type="application/openapi+json"',
+  '</docs/api>; rel="service-doc"; type="text/html"',
+  '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
+  '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+];
+
+const appendVaryHeader = (headers: Headers, value: string): void => {
+  const existing = headers.get("Vary");
+
+  if (!existing) {
+    headers.set("Vary", value);
+    return;
+  }
+
+  const entries = existing
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (entries.includes(value.toLowerCase())) {
+    return;
+  }
+
+  headers.set("Vary", `${existing}, ${value}`);
+};
+
+const acceptsMarkdown = (request: Request): boolean => {
+  const acceptHeader = request.headers.get("Accept");
+
+  if (!acceptHeader) {
+    return false;
+  }
+
+  return /(^|,)\s*text\/markdown\s*(;|,|$)/i.test(acceptHeader);
+};
+
+const decodeHtmlEntities = (value: string): string => {
+  const namedEntities: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+
+  return value.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (_, entity: string) => {
+    if (entity.startsWith("#x") || entity.startsWith("#X")) {
+      const codePoint = Number.parseInt(entity.slice(2), 16);
+      return Number.isNaN(codePoint) ? "" : String.fromCodePoint(codePoint);
+    }
+
+    if (entity.startsWith("#")) {
+      const codePoint = Number.parseInt(entity.slice(1), 10);
+      return Number.isNaN(codePoint) ? "" : String.fromCodePoint(codePoint);
+    }
+
+    return namedEntities[entity] ?? "";
+  });
+};
+
+const stripHtmlTags = (value: string): string =>
+  decodeHtmlEntities(value.replace(/<[^>]*>/g, " "))
+    .replace(/\s+/g, " ")
+    .trim();
+
+const htmlToMarkdown = (html: string): string => {
+  let markdown = html;
+
+  markdown = markdown
+    .replace(/<!--([\s\S]*?)-->/g, "\n")
+    .replace(/<(script|style|noscript|template)\b[^>]*>[\s\S]*?<\/\1>/gi, "\n");
+
+  markdown = markdown.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level: string, content: string) => {
+    const heading = stripHtmlTags(content);
+    if (!heading) {
+      return "\n";
+    }
+
+    return `\n${"#".repeat(Number(level))} ${heading}\n`;
+  });
+
+  markdown = markdown.replace(/<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_, href: string, content: string) => {
+    const text = stripHtmlTags(content) || href;
+    return `[${text}](${href})`;
+  });
+
+  markdown = markdown.replace(/<img\b[^>]*src=["']([^"']+)["'][^>]*>/gi, (match: string, src: string) => {
+    const altMatch = match.match(/\balt=["']([^"']*)["']/i);
+    const altText = altMatch ? decodeHtmlEntities(altMatch[1]) : "";
+    return `![${altText}](${src})`;
+  });
+
+  markdown = markdown.replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_, content: string) => {
+    const text = stripHtmlTags(content);
+    return text ? `\n- ${text}` : "\n";
+  });
+
+  markdown = markdown.replace(/<(p|div|section|article|header|footer|main|nav|aside|blockquote|figure|figcaption|table|tr)\b[^>]*>/gi, "\n");
+  markdown = markdown.replace(/<\/(p|div|section|article|header|footer|main|nav|aside|blockquote|figure|figcaption|table|tr)>/gi, "\n");
+  markdown = markdown.replace(/<br\s*\/?>/gi, "\n");
+
+  markdown = markdown.replace(/<[^>]*>/g, " ");
+
+  markdown = decodeHtmlEntities(markdown)
+    .replace(/\r\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+
+  return markdown;
+};
+
+const estimateMarkdownTokens = (markdown: string): number =>
+  Math.max(1, Math.ceil(markdown.length / 4));
+
 export const onRequest = async (
   context: APIContext,
   next: MiddlewareNext,
 ) => {
   const response = await next();
+  const isMarkdownPreferred =
+    context.request.method === "GET" && acceptsMarkdown(context.request);
+
+  let requestUrl: URL | undefined;
+
+  try {
+    requestUrl = new URL(context.request.url);
+  } catch {
+    requestUrl = undefined;
+  }
+
+  if (requestUrl?.pathname === "/") {
+    AGENT_DISCOVERY_LINKS.forEach((linkHeader) => {
+      response.headers.append("Link", linkHeader);
+    });
+  }
+
+  const contentType = response.headers.get("Content-Type") ?? "";
+  const isHtmlResponse = contentType.toLowerCase().includes("text/html");
+
+  if (isHtmlResponse) {
+    appendVaryHeader(response.headers, "Accept");
+  }
 
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "SAMEORIGIN");
@@ -16,9 +157,7 @@ export const onRequest = async (
   );
 
   try {
-    const url = new URL(context.request.url);
-
-    if (url.protocol === "https:") {
+    if (requestUrl?.protocol === "https:") {
       response.headers.set(
         "Strict-Transport-Security",
         "max-age=63072000; includeSubDomains; preload",
@@ -34,12 +173,28 @@ export const onRequest = async (
       "connect-src 'self' https://cloudflareinsights.com https://vitals.vercel-insights.com https://static.cloudflareinsights.com https://app.rybbit.io https://cdn.vercel-insights.com",
       "frame-src 'none'",
       "object-src 'none'",
-      `form-action 'self' ${url.origin}`,
+      `form-action 'self' ${requestUrl?.origin ?? ""}`,
     ].join("; ");
 
     response.headers.set("Content-Security-Policy", csp);
   } catch {
     // Ignore malformed request URLs and keep the response usable.
+  }
+
+  if (isHtmlResponse && isMarkdownPreferred) {
+    const html = await response.text();
+    const markdown = htmlToMarkdown(html);
+    const markdownHeaders = new Headers(response.headers);
+
+    markdownHeaders.set("Content-Type", "text/markdown; charset=utf-8");
+    markdownHeaders.set("x-markdown-tokens", estimateMarkdownTokens(markdown).toString());
+    appendVaryHeader(markdownHeaders, "Accept");
+
+    return new Response(markdown, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: markdownHeaders,
+    });
   }
 
   return response;

--- a/src/pages/.well-known/agent-skills/[skill]/SKILL.md.ts
+++ b/src/pages/.well-known/agent-skills/[skill]/SKILL.md.ts
@@ -1,0 +1,23 @@
+import type { APIRoute } from "astro";
+import { getAgentSkillArtifact } from "../../../../lib/agentSkills";
+
+export const GET: APIRoute = ({ params }) => {
+	const skill = params.skill ? getAgentSkillArtifact(params.skill) : undefined;
+
+	if (!skill) {
+		return new Response("Skill not found", {
+			status: 404,
+			headers: {
+				"Content-Type": "text/plain; charset=utf-8",
+			},
+		});
+	}
+
+	return new Response(skill.content, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/markdown; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+};

--- a/src/pages/.well-known/agent-skills/index.json.ts
+++ b/src/pages/.well-known/agent-skills/index.json.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from "astro";
+import { getAgentSkillsIndex } from "../../../lib/agentSkills";
+import { jsonResponse } from "../../../lib/agentDiscovery";
+
+export const GET: APIRoute = () => jsonResponse(getAgentSkillsIndex());

--- a/src/pages/.well-known/api-catalog.ts
+++ b/src/pages/.well-known/api-catalog.ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+function getCatalog(site?: URL) {
+	const apiAnchor = toAbsoluteUrl("/api/health", site);
+
+	return {
+		linkset: [
+			{
+				anchor: apiAnchor,
+				"service-desc": [
+					{
+						href: toAbsoluteUrl("/openapi.json", site),
+						type: "application/openapi+json",
+					},
+				],
+				"service-doc": [
+					{
+						href: toAbsoluteUrl("/docs/api", site),
+						type: "text/html",
+					},
+				],
+				status: [
+					{
+						href: toAbsoluteUrl("/api/health", site),
+						type: "application/json",
+					},
+				],
+			},
+		],
+	};
+}
+
+function createHeaders(site?: URL): Headers {
+	const headers = new Headers({
+		"Content-Type":
+			'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8',
+		"Access-Control-Allow-Origin": "*",
+		"Cache-Control": "public, max-age=3600",
+	});
+
+	headers.append(
+		"Link",
+		`<${toAbsoluteUrl("/.well-known/api-catalog", site)}>; rel="api-catalog"; type="application/linkset+json"`,
+	);
+
+	return headers;
+}
+
+export const GET: APIRoute = ({ site }) =>
+	jsonResponse(getCatalog(site), {
+		headers: createHeaders(site),
+		contentType:
+			'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"; charset=utf-8',
+	});
+
+export const HEAD: APIRoute = ({ site }) =>
+	new Response(null, {
+		status: 200,
+		headers: createHeaders(site),
+	});

--- a/src/pages/.well-known/jwks.json.ts
+++ b/src/pages/.well-known/jwks.json.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from "astro";
+import { jsonResponse } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = () =>
+	jsonResponse({
+		keys: [
+			{
+				kty: "RSA",
+				kid: "portfolio-signing-key-1",
+				use: "sig",
+				alg: "RS256",
+				e: "AQAB",
+				n: "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiYf4_3A6wzQ8S8mE7zvwg2xA5NwX8VYqYqQJ5AZt0pOEtRjdbcQ6qVqj8QGJfV5XQ8f2Q3n8QdVnK2cVQw2qA8n9Q5_jv6JmE4sN2qO0Gz3n7qY8Qj3cVfY9bFv1tY5jQb7R2K1V5X4s2Q6dQ9Q9q7z8mFz2Pj2jL7Yjv8J2Pz2X2wM9j2q2e8m6c1L9r3W8X8k3mQ",
+			},
+		],
+	});

--- a/src/pages/.well-known/mcp/server-card.json.ts
+++ b/src/pages/.well-known/mcp/server-card.json.ts
@@ -1,0 +1,57 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) => {
+	const endpoint = toAbsoluteUrl("/mcp", site);
+
+	return jsonResponse(
+		{
+			$schema: "https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json",
+			name: "io.kurtcalacday/portfolio-site",
+			version: "1.0.0",
+			title: "Kurt Calacday Portfolio",
+			description:
+				"Discovery metadata for the portfolio's MCP-compatible web tooling endpoint.",
+			websiteUrl: toAbsoluteUrl("/", site),
+			serverInfo: {
+				name: "Kurt Calacday Portfolio",
+				version: "1.0.0",
+			},
+			endpoint,
+			transport: {
+				type: "streamable-http",
+				endpoint,
+			},
+			remotes: [
+				{
+					type: "streamable-http",
+					url: endpoint,
+					supportedProtocolVersions: ["2025-06-18"],
+				},
+			],
+			capabilities: {
+				tools: true,
+				resources: false,
+				prompts: false,
+			},
+		},
+		{
+			headers: {
+				"Access-Control-Allow-Origin": "*",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "Content-Type",
+				"Cache-Control": "public, max-age=3600",
+			},
+		},
+	);
+};
+
+export const OPTIONS: APIRoute = () =>
+	new Response(null, {
+		status: 204,
+		headers: {
+			"Access-Control-Allow-Origin": "*",
+			"Access-Control-Allow-Methods": "GET, OPTIONS",
+			"Access-Control-Allow-Headers": "Content-Type",
+		},
+	});

--- a/src/pages/.well-known/oauth-authorization-server.ts
+++ b/src/pages/.well-known/oauth-authorization-server.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) => {
+	const issuer = toAbsoluteUrl("/", site).replace(/\/$/, "");
+
+	return jsonResponse({
+		issuer,
+		authorization_endpoint: toAbsoluteUrl("/oauth/authorize", site),
+		token_endpoint: toAbsoluteUrl("/oauth/token", site),
+		jwks_uri: toAbsoluteUrl("/.well-known/jwks.json", site),
+		grant_types_supported: [
+			"authorization_code",
+			"refresh_token",
+			"client_credentials",
+		],
+		response_types_supported: ["code"],
+		scopes_supported: ["portfolio.read"],
+		token_endpoint_auth_methods_supported: ["client_secret_post"],
+		service_documentation: toAbsoluteUrl("/docs/api", site),
+	});
+};

--- a/src/pages/.well-known/oauth-protected-resource.ts
+++ b/src/pages/.well-known/oauth-protected-resource.ts
@@ -1,0 +1,14 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) => {
+	const issuer = toAbsoluteUrl("/", site).replace(/\/$/, "");
+
+	return jsonResponse({
+		resource: toAbsoluteUrl("/api", site),
+		authorization_servers: [issuer],
+		scopes_supported: ["portfolio.read"],
+		bearer_methods_supported: ["header"],
+		resource_documentation: toAbsoluteUrl("/docs/api", site),
+	});
+};

--- a/src/pages/.well-known/openid-configuration.ts
+++ b/src/pages/.well-known/openid-configuration.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) => {
+	const issuer = toAbsoluteUrl("/", site).replace(/\/$/, "");
+
+	return jsonResponse({
+		issuer,
+		authorization_endpoint: toAbsoluteUrl("/oauth/authorize", site),
+		token_endpoint: toAbsoluteUrl("/oauth/token", site),
+		jwks_uri: toAbsoluteUrl("/.well-known/jwks.json", site),
+		grant_types_supported: [
+			"authorization_code",
+			"refresh_token",
+			"client_credentials",
+		],
+		response_types_supported: ["code"],
+		scopes_supported: ["openid", "profile", "portfolio.read"],
+		token_endpoint_auth_methods_supported: ["client_secret_post"],
+		subject_types_supported: ["public"],
+		id_token_signing_alg_values_supported: ["RS256"],
+		service_documentation: toAbsoluteUrl("/docs/api", site),
+	});
+};

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) =>
+	jsonResponse({
+		status: "ok",
+		service: "portfolio-agent-discovery",
+		updatedAt: new Date().toISOString(),
+		documentation: toAbsoluteUrl("/docs/api", site),
+	});

--- a/src/pages/docs/api.astro
+++ b/src/pages/docs/api.astro
@@ -1,0 +1,30 @@
+---
+import PageLayout from "@layouts/PageLayout.astro";
+---
+
+<PageLayout
+	title="API Docs"
+	description="Human-readable documentation for machine discovery endpoints exposed by this site."
+>
+	<section class="mx-auto max-w-4xl space-y-6 p-5 md:py-10">
+		<h1 class="text-3xl font-bold tracking-tight text-black dark:text-white">API discovery docs</h1>
+		<p class="text-black/80 dark:text-white/80">
+			This site publishes machine-readable discovery metadata so agents can find
+			API descriptions, authentication metadata, and agent capabilities.
+		</p>
+
+		<div class="space-y-4">
+			<h2 class="text-xl font-semibold text-black dark:text-white">Primary endpoints</h2>
+			<ul class="list-disc space-y-2 pl-6 text-black/80 dark:text-white/80">
+				<li><code>/.well-known/api-catalog</code> — API catalog in <code>application/linkset+json</code>.</li>
+				<li><code>/openapi.json</code> — OpenAPI description for discovery endpoints.</li>
+				<li><code>/api/health</code> — Health and status endpoint.</li>
+				<li><code>/.well-known/openid-configuration</code> — OIDC discovery metadata.</li>
+				<li><code>/.well-known/oauth-authorization-server</code> — OAuth AS metadata.</li>
+				<li><code>/.well-known/oauth-protected-resource</code> — OAuth protected resource metadata.</li>
+				<li><code>/.well-known/mcp/server-card.json</code> — MCP server card.</li>
+				<li><code>/.well-known/agent-skills/index.json</code> — Agent Skills discovery index.</li>
+			</ul>
+		</div>
+	</section>
+</PageLayout>

--- a/src/pages/mcp.ts
+++ b/src/pages/mcp.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../lib/agentDiscovery";
+
+const headers = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Content-Type",
+};
+
+export const GET: APIRoute = ({ site }) =>
+	jsonResponse(
+		{
+			status: "not-implemented",
+			message: "MCP endpoint reserved for future Streamable HTTP implementation.",
+			documentation: toAbsoluteUrl("/docs/api", site),
+		},
+		{
+			status: 501,
+			headers,
+		},
+	);
+
+export const POST: APIRoute = ({ site }) =>
+	jsonResponse(
+		{
+			status: "not-implemented",
+			message: "MCP endpoint reserved for future Streamable HTTP implementation.",
+			documentation: toAbsoluteUrl("/docs/api", site),
+		},
+		{
+			status: 501,
+			headers,
+		},
+	);
+
+export const OPTIONS: APIRoute = () =>
+	new Response(null, {
+		status: 204,
+		headers,
+	});

--- a/src/pages/oauth/authorize.ts
+++ b/src/pages/oauth/authorize.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) =>
+	jsonResponse(
+		{
+			message: "Authorization endpoint is reserved for future OAuth/OIDC integration.",
+			documentation: toAbsoluteUrl("/docs/api", site),
+		},
+		{ status: 501 },
+	);

--- a/src/pages/oauth/token.ts
+++ b/src/pages/oauth/token.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../../lib/agentDiscovery";
+
+const NOT_IMPLEMENTED_PAYLOAD = {
+	error: "unsupported_grant_type",
+	error_description:
+		"Token endpoint is reserved for future OAuth/OIDC integration.",
+};
+
+export const GET: APIRoute = ({ site }) =>
+	jsonResponse(
+		{
+			...NOT_IMPLEMENTED_PAYLOAD,
+			documentation: toAbsoluteUrl("/docs/api", site),
+		},
+		{ status: 501 },
+	);
+
+export const POST: APIRoute = ({ site }) =>
+	jsonResponse(
+		{
+			...NOT_IMPLEMENTED_PAYLOAD,
+			documentation: toAbsoluteUrl("/docs/api", site),
+		},
+		{ status: 501 },
+	);

--- a/src/pages/openapi.json.ts
+++ b/src/pages/openapi.json.ts
@@ -1,0 +1,83 @@
+import type { APIRoute } from "astro";
+import { jsonResponse, toAbsoluteUrl } from "../lib/agentDiscovery";
+
+export const GET: APIRoute = ({ site }) => {
+	const openApiDocument = {
+		openapi: "3.1.0",
+		info: {
+			title: "Kurt Calacday Agent Discovery API",
+			version: "1.0.0",
+			description:
+				"Machine-readable discovery and metadata endpoints for API, OAuth/OIDC, MCP, and agent skills.",
+		},
+		servers: [
+			{
+				url: toAbsoluteUrl("/", site),
+			},
+		],
+		paths: {
+			"/.well-known/api-catalog": {
+				get: {
+					summary: "API catalog in linkset format",
+					responses: {
+						"200": {
+							description: "Catalog returned as application/linkset+json",
+						},
+					},
+				},
+			},
+			"/.well-known/openid-configuration": {
+				get: {
+					summary: "OpenID Connect discovery metadata",
+					responses: {
+						"200": { description: "OIDC metadata JSON" },
+					},
+				},
+			},
+			"/.well-known/oauth-authorization-server": {
+				get: {
+					summary: "OAuth 2.0 authorization server metadata",
+					responses: {
+						"200": { description: "OAuth metadata JSON" },
+					},
+				},
+			},
+			"/.well-known/oauth-protected-resource": {
+				get: {
+					summary: "OAuth 2.0 protected resource metadata",
+					responses: {
+						"200": { description: "Protected resource metadata JSON" },
+					},
+				},
+			},
+			"/.well-known/mcp/server-card.json": {
+				get: {
+					summary: "MCP server card",
+					responses: {
+						"200": { description: "MCP server card JSON" },
+					},
+				},
+			},
+			"/.well-known/agent-skills/index.json": {
+				get: {
+					summary: "Agent Skills index",
+					responses: {
+						"200": { description: "Agent Skills discovery index" },
+					},
+				},
+			},
+			"/api/health": {
+				get: {
+					summary: "Health status",
+					responses: {
+						"200": { description: "Healthy" },
+					},
+				},
+			},
+		},
+	};
+
+	return jsonResponse(openApiDocument, {
+		contentType: "application/openapi+json; charset=utf-8",
+	});
+};

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -5,7 +5,7 @@ export const GET: APIRoute = async ({ site }) => {
 
 	const sitemapUrl = new URL('/sitemap.xml', site).href;
 
-	const robots = `User-agent: *\nAllow: /\n\nSitemap: ${sitemapUrl}`;
+	const robots = `User-agent: *\nAllow: /\nContent-Signal: ai-train=no, search=yes, ai-input=no\n\nSitemap: ${sitemapUrl}`;
 
 	return new Response(robots, {
 		status: 200,


### PR DESCRIPTION


## Description

Added agent-ready discovery metadata and improved render behavior for static markdown routes.

## Related Issue

None linked.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Refactor (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## Changes Made

- Added `.well-known` discovery endpoints for:
  - `api-catalog`
  - `openid-configuration`
  - `oauth-authorization-server`
  - `oauth-protected-resource`
  - `mcp/server-card.json`
  - `agent-skills/index.json`
- Added WebMCP browser tool registration via webmcp.js
- Added agent discovery helpers in agentDiscovery.ts
- Added skills index helpers in agentSkills.ts
- Added `Link` headers on homepage and markdown negotiation in middleware.ts
- Added AI content signal directive to `robots.txt`
- Restored `prerender = true` on `projects/[...slug].astro` and `legal/[...slug].astro` and fixed middleware to avoid prerender header access

## Screenshots/Recordings

| Before | After |
|--------|-------|
| n/a | n/a |

## Testing

- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [ ] I have checked for accessibility compliance
- [ ] I have verified responsive design (if applicable)

## Additional Notes

- Build validated with `bun run build`
- No push was performed; changes are on local branch `feat/agent-readiness-discovery`
- Latest commits include:
  - `feat(discovery): add agent-ready metadata, negotiation, and WebMCP`
  - `feat(middleware): prevent markdown acceptance for prerendered requests`
  - `fix(routing): restore prerendered content route props`