### PR TITLE
feat: consolidate W.I.P. badges, add placeholder fallback, fix icon dark mode

### DIFF
--- a/src/components/ArrowCard.tsx
+++ b/src/components/ArrowCard.tsx
@@ -46,6 +46,19 @@ export default function ArrowCard({ entry, pill, tagOptions, truncateTags }: Pro
       href={`/projects/${entry.id}`}
       className="group relative flex flex-col rounded-xl border border-border/60 bg-card overflow-hidden transition-all duration-300 ease-out hover:border-accent/40 hover:shadow-[0_1px_3px_0_oklch(0.672_0.1308_38.76/0.25)]"
     >
+      {/* Draft W.I.P. scotch tape */}
+      {entry.data.draft && (
+        <div className="pointer-events-none absolute top-0 right-0 z-10 h-full w-full overflow-hidden rounded-xl">
+          <div className="absolute top-4 right-[-65px] w-52 rotate-[43deg]">
+            <div className="bg-[repeating-linear-gradient(135deg,#000_0_4px,#facc15_4px_8px)] px-4 py-2.5 shadow-xs">
+              <span className="block bg-yellow-400 text-center text-sm font-black uppercase tracking-widest text-black">
+                W.I.P.
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Image */}
       {hasImage && (
         <div className="relative aspect-[16/10] w-full overflow-hidden">
@@ -78,20 +91,12 @@ export default function ArrowCard({ entry, pill, tagOptions, truncateTags }: Pro
               <h3 className="text-base font-semibold leading-snug tracking-tight text-foreground line-clamp-1 group-hover:text-accent transition-colors duration-300">
                 {entry.data.title}
               </h3>
-              {entry.data.draft && (
-                <span className="relative shrink-0 rounded-sm bg-yellow-400 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wider text-black">
-                  <span className="absolute inset-x-0 top-0 h-[2px] bg-[repeating-linear-gradient(90deg,#000_0_3px,transparent_3px_6px)]" />
-                  W.I.P.
-                  <span className="absolute inset-x-0 bottom-0 h-[2px] bg-[repeating-linear-gradient(90deg,#000_0_3px,transparent_3px_6px)]" />
-                </span>
-              )}
             </div>
             <time className="mt-1 block text-sm text-muted-foreground">
               {formatDate(entry.data.date)}
             </time>
           </div>
 
-          {/* Arrow indicator */}
           <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted/30 text-muted-foreground transition-all duration-300 group-hover:border-accent/40 group-hover:bg-accent/10 group-hover:text-accent">
             <ArrowUpRight
               size={14}

--- a/src/components/GlobalSearchDialog.tsx
+++ b/src/components/GlobalSearchDialog.tsx
@@ -73,10 +73,10 @@ function ProjectResultItem({
         </div>
         <span className="truncate text-sm font-medium">{project.title}</span>
         {project.draft && (
-          <span className="relative shrink-0 rounded-sm bg-yellow-400 px-1.5 py-0.5 text-[9px] font-black uppercase tracking-wider text-black">
-            <span className="absolute inset-x-0 top-0 h-[2px] bg-[repeating-linear-gradient(90deg,#000_0_3px,transparent_3px_6px)]" />
-            W.I.P.
-            <span className="absolute inset-x-0 bottom-0 h-[2px] bg-[repeating-linear-gradient(90deg,#000_0_3px,transparent_3px_6px)]" />
+          <span className="relative shrink-0 rotate-[-2deg] bg-[repeating-linear-gradient(-45deg,#000_0_2px,#facc15_2px_4px)] px-2 py-0.5">
+            <span className="block bg-yellow-400 px-1.5 text-xs font-black uppercase tracking-widest text-black">
+              W.I.P.
+            </span>
           </span>
         )}
         <span className="ml-auto shrink-0 text-[10px] text-muted-foreground opacity-0 transition-opacity group-data-[selected]/command-item:opacity-100">

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -12,7 +12,11 @@ export function TagIcon({ tag, className }: { className?: string; tag: TagOption
   if (!tag.iconPath) return null;
 
   const isInvertedBrand =
-    tag.iconSlug === "nextdotjs" || tag.iconSlug === "shadcnui" || tag.iconSlug === "tanstack";
+    tag.iconSlug === "nextdotjs" ||
+    tag.iconSlug === "shadcnui" ||
+    tag.iconSlug === "tanstack" ||
+    tag.iconSlug === "rust" ||
+    tag.iconSlug === "bun";
 
   return (
     <svg

--- a/src/content/projects/2026/envexa.md
+++ b/src/content/projects/2026/envexa.md
@@ -1,0 +1,119 @@
+---
+title: "Envexa - Security Toolchain Health Monitor"
+summary: "🚧 Blazing-fast Rust TUI and scriptable CLI for monitoring local developer tooling health. Instantly track outdated packages and audit security risks across 14+ toolchains."
+date: "May 22, 2026"
+draft: true
+tags:
+- Rust
+- Tanstack
+- Tailwind
+- Shadcn/ui
+demoUrl: https://github.com/KurutoDenzeru/envexa
+repoUrl: https://github.com/KurutoDenzeru/envexa
+coverAlt: 'Envexa - Security Toolchain Health Monitor'
+---
+
+---
+
+## ☁️ Deploy your own
+
+<div style="display: flex; gap: 1rem; align-items: center; margin-bottom: 1.5rem;">
+  <a href="https://vercel.com/new/clone?repository-url=https://github.com/KurutoDenzeru/Envexa">
+    <img src="https://vercel.com/button" alt="Deploy with Vercel"/>
+  </a>
+  <a href="https://app.netlify.com/start/deploy?repository=https://github.com/KurutoDenzeru/Envexa">
+    <img src="https://www.netlify.com/img/deploy/button.svg" alt="Deploy to Netlify">
+  </a>
+</div>
+
+---
+
+## ✨ Features
+
+- **Concurrent Engine**: Scans 14+ toolchains (Homebrew, npm, Cargo, Docker, etc.) in parallel.
+- **Interactive TUI**: Features custom pie charts, health gauges, and quick keyboard navigation.
+- **Project Tooling Sector**: Deep-dives into local lockfiles, dependency drift, and security audits.
+- **CLI Reports**: Generates production-ready Markdown reports instantly for CI/CD or PRs.
+- **Smart Cache**: Zero-friction launches utilizing local JSON state (`~/.envexa/cache.json`).
+
+---
+
+## 🧱 Tech Stack
+
+- [React](https://react.dev/): UI framework for declarative component rendering.
+- [TanStack Router](https://tanstack.com/router): Declarative client-side routing with nested layouts.
+- [TypeScript](https://www.typescriptlang.org/): Strong typing for safer maintenance and refactoring.
+- [Tailwind](https://tailwindcss.com/): Utility-first styling used across components.
+- [Shadcn UI](https://ui.shadcn.com/): Base design primitives for consistent interface components.
+
+---
+
+## 🚀 Getting Started
+
+Clone the repo, install deps, and boot the dev server:
+
+```bash
+git clone https://github.com/KurutoDenzeru/Ketch.git
+cd Ketch
+bun install
+bun run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to view the app.
+
+## 📦 Build for Production
+
+```bash
+bun run build
+bun start
+```
+
+---
+
+## 🗂️ Configuration
+
+The app is implemented under `src/`. Key areas to customize and extend are:
+
+```text
+envexa/
+├── Cargo.toml
+├── src/
+│   ├── main.rs             # Application entrypoint (TUI or CLI router)
+│   ├── cli.rs              # CLI command parser and runner
+│   ├── config.rs           # Persistent configurations and cached state
+│   ├── scanner/
+│   │   └── mod.rs          # Formatting utilities and diagnostic extraction
+│   ├── tui/
+│   │   ├── app.rs          # App state management, keyboard events, and scheduler
+│   │   ├── mod.rs
+│   │   └── ui.rs           # Ratatui rendering pipeline and interface structures
+│   └── toolchains/
+│       ├── mod.rs          # ScanResult schema, protocols, and multi-thread runners
+│       ├── brew.rs
+│       ├── npm.rs / pnpm.rs / yarn.rs / bun.rs / deno.rs
+│       ├── pip.rs / gem.rs / cargo.rs / docker.rs
+│       └── project.rs / security.rs / audit.rs / ci.rs
+├── scripts/
+│   ├── install.sh
+│   └── build-and-upload.sh
+└── .github/
+    └── workflows/
+```
+
+---
+
+## 🤝 Contributing
+
+Contributions are always welcome, whether you're fixing bugs, improving docs, or shipping new features that make the project better for everyone.
+
+Check out [Contributing.md](Contributing) to learn how to get started and follow the recommended workflow.
+
+<!-- Please adhere to this project's `Code of Conduct`. -->
+
+---
+
+## ⚖️ License
+
+This project is released under the MIT License, giving you the freedom to use, modify, and distribute the code with minimal restrictions.
+
+For the full legal text, see the [MIT](LICENSE) file.

--- a/src/content/projects/2026/hazr.md
+++ b/src/content/projects/2026/hazr.md
@@ -2,7 +2,7 @@
 title: "Hazr - Live Weather, Earthquakes, Air Quality, & Global Alerts"
 summary: "🗺️ Real-time geospatial hazard dashboard built with Vite, React, & MapLibre, powered by USGS Earthquakes, Open-Meteo Weather, NASA EONET Signals, OpenAQ, & NWS Alerts."
 date: "Jan 07, 2026"
-draft: true
+draft: false
 tags:
 - React
 - Vite

--- a/src/content/projects/2026/ketch.md
+++ b/src/content/projects/2026/ketch.md
@@ -2,14 +2,13 @@
 title: "Ketch - AI Startup Idea Lab"
 summary: "✨ Idea workshop for instant brainstorming, local save/slug sharing, powered by React, TypeScript, Tailwind, TanStack Router, and shadcn/ui."
 date: "Mar 09, 2026"
-draft: false
+draft: true
 tags:
+- AI
 - Tanstack
 - Typescript
-- React
 - Tailwind
 - Shadcn/ui
-- AI
 demoUrl: https://ketch.krtclcdy.workers.dev/
 repoUrl: https://github.com/KurutoDenzeru/Ketch
 coverAlt: 'Ketch - AI Startup Idea Lab'

--- a/src/lib/projectPreviews.ts
+++ b/src/lib/projectPreviews.ts
@@ -124,7 +124,7 @@ export async function resolveProjectPreview(entry: ProjectEntry) {
     if (image) return image;
   }
 
-  return entry.data.coverImage?.src;
+  return entry.data.coverImage?.src ?? "/placeholder.webp";
 }
 
 export async function withProjectPreview(entry: ProjectEntry): Promise<ProjectEntryWithPreview> {


### PR DESCRIPTION
## Description

Improvements to project card UI: consolidated W.I.P. badge design to only appear as scotch tape at the top-right of cards, added placeholder image fallback for projects without OG images, and fixed dark mode visibility for Rust and Bun project tag icons.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 Style/UI update

## Changes Made

- Consolidated W.I.P. badge to scotch tape ribbon at top-right of project cards only (removed duplicate inline badge next to title in ArrowCard)
- Redesigned W.I.P. badge in global search dialog with caution-tape diagonal stripe style
- Added `/placeholder.webp` fallback for projects without OG images or cover images
- Fixed Rust and Bun icon visibility in dark mode by adding to inverted-brand icon list
- Published hazr.md project (draft → published)
- Added envexa.md as new draft project entry

## Screenshots/Recordings

| Before | After |
|--------|-------|
| (no change visible — style adjustments) | W.I.P. badge only at top-right; placeholder shown for image-less projects; icons visible in dark mode |

## Testing

- [x] I have tested this locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [ ] I have checked for accessibility compliance
- [ ] I have verified responsive design (if applicable)

## Additional Notes

All local W.I.P. changes were preserved through a stash/pull/pop workflow that resolved a merge conflict in GlobalSearchDialog.tsx.